### PR TITLE
Refactor: Memoize generateClassnamesListSync

### DIFF
--- a/lib/util/cssFiles.js
+++ b/lib/util/cssFiles.js
@@ -9,6 +9,7 @@ const REFRESH_RATE = 5000;
 let previousGlobsResults = [];
 let lastUpdate = new Date().getTime() - REFRESH_RATE;
 let classnamesFromFiles = [];
+const regexp = /\.([^\.\,\s\n\:\(\)\[\]\'~\+\>\*\\]*)/gim;
 
 // Store results of previous calls
 const memo = {};
@@ -34,7 +35,6 @@ const generateClassnamesListSync = (patterns) => {
       const data = fs.readFileSync(file, 'utf-8');
       const root = postcss.parse(data);
       root.walkRules((rule) => {
-        const regexp = /\.([^\.\,\s\n\:\(\)\[\]\'~\+\>\*\\]*)/gim;
         const matches = [...rule.selector.matchAll(regexp)];
         const classnames = matches.map((arr) => arr[1]);
         detectedClassnames.push(...classnames);

--- a/lib/util/cssFiles.js
+++ b/lib/util/cssFiles.js
@@ -10,12 +10,18 @@ let previousGlobsResults = [];
 let lastUpdate = new Date().getTime() - REFRESH_RATE;
 let classnamesFromFiles = [];
 
+// Store results of previous calls
+const memo = {};
+
 /**
  * Read CSS files and extract classnames
  * @param {Array} patterns Glob patterns to locate files
  * @returns {Array} List of classnames
  */
 const generateClassnamesListSync = (patterns) => {
+  const stringifiedPatterns = JSON.stringify(patterns);
+  if (memo[stringifiedPatterns]) return memo[stringifiedPatterns];
+
   const now = new Date().getTime();
   const files = fg.sync(patterns);
   const newGlobs = previousGlobsResults.flat().join(',') != files.flat().join('');
@@ -37,6 +43,7 @@ const generateClassnamesListSync = (patterns) => {
     }
     classnamesFromFiles = detectedClassnames;
   }
+  memo[stringifiedPatterns] = classnamesFromFiles;
   return classnamesFromFiles;
 };
 


### PR DESCRIPTION
# Refactor: Memoize generateClassnamesListSync

This is my first contribution to this repository. Please excuse any mistakes or lack of awareness. 🙏 I suspect that this solution _might not_ be acceptable. I.e. memoizing this function _might_ actually break how the plugin works. 🤔 

This fix seems simple enough that _the PR itself_ is the best way to identify the problem and propose a solution.

## Description

My team uses `eslint-plugin-tailwindcss` for a project with ~400 files.

I observed that _when we started using this plugin_, the execution time for `eslint` changed **dramatically**.

| Without `eslint-plugin-tailwindcss` `29 seconds` | With `eslint-plugin-tailwindcss` `684 seconds` |
| - | - |
| <img width="2160" alt="Screen Shot 2022-01-09 at 13 09 50" src="https://user-images.githubusercontent.com/535311/148712075-fc6800d7-1c52-4921-9a90-f7beb3fb904d.png"> | <img width="2160" alt="Screen Shot 2022-01-09 at 13 21 58" src="https://user-images.githubusercontent.com/535311/148669731-5b734837-d6d5-499b-a4ab-702b2d88640d.png"> |

### Investigation

I wanted to know what function calls are taking the most time. I ran `eslint` (with the plugin engaged) on a subset of files. I used the Google Chrome profiler.

<img width="2048" alt="Screen Shot 2022-01-09 at 13 42 44" src="https://user-images.githubusercontent.com/535311/148669809-8e427fd3-5638-4d10-b454-79ba270576ef.png">

It seemed clear that the most expensive function calls were `readdir`. The piece of code _within the plugin_ that called `readdir` was `generateClassnamesListSync`.

I added some console logs to see what `generateClassnamesListSync` was doing.

<img width="2048" alt="Screen Shot 2022-01-10 at 11 43 28" src="https://user-images.githubusercontent.com/535311/148712803-9a645bb4-0b76-4327-a4fa-6e1de2b5a9e8.png">

🎉  `generateClassnamesListSync` was taking _many seconds_ for each invocation. And, it always returned the same result. Thus, it seemed like _memoization_ would be an easy fix. 👈 Memoization is the essence of this PR.

With the fix, I am able to run `eslint` on the entire codebase, and it takes _about the same amount of time_ as before.

<img width="2160" alt="Screen Shot 2022-01-09 at 13 25 52" src="https://user-images.githubusercontent.com/535311/148669727-5a8ec237-498f-46c8-b57f-5cb9d89ef2a7.png">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

There is no logical change whatsoever, so the existing tests should be sufficient.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

---

If possible, I think this code change should be integrated and released as a _patch_ for all major versions.